### PR TITLE
Do not use res.send() inside the module as it breaks middleware chain.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
+  - "4.2"
   - "0.12"
   - "0.10"
   - "iojs"

--- a/lib/restifyroutes.js
+++ b/lib/restifyroutes.js
@@ -95,6 +95,7 @@ function makeValidator(validator, consumes) {
 
         validate(value, function (error, newvalue) {
             if (error) {
+                error.status = 400;
                 next(error);
                 return;
             }

--- a/lib/restifyroutes.js
+++ b/lib/restifyroutes.js
@@ -95,7 +95,6 @@ function makeValidator(validator, consumes) {
 
         validate(value, function (error, newvalue) {
             if (error) {
-                res.send(400);
                 next(error);
                 return;
             }

--- a/package.json
+++ b/package.json
@@ -27,25 +27,25 @@
   },
   "bugs": "http://github.com/bardzusny/swaggerize-restify/issues",
   "engines": {
-    "node": "0.10.x"
+    "node": ">=0.10.x"
   },
   "dependencies": {
-    "async": "^0.9.0",
-    "caller": "^0.0.1",
-    "core-util-is": "^1.0.1",
+    "async": "^1.5.2",
+    "caller": "^1.0.1",
+    "core-util-is": "^1.0.2",
     "debuglog": "^1.0.1",
-    "js-yaml": "^3.2.6",
-    "swaggerize-routes": "^1.0.0"
+    "js-yaml": "^3.5.2",
+    "swaggerize-routes": "^1.0.6"
   },
   "peerDependencies": {
-    "restify": "^3.0.3"
+    "restify": "^4.0.3"
   },
   "devDependencies": {
-    "tape": "^2.4.2",
-    "istanbul": "^0.2.3",
-    "jshint": "^2.4.1",
-    "restify": "^3.0.3",
-    "supertest": "^0.13.0"
+    "istanbul": "^0.4.2",
+    "jshint": "^2.9.1",
+    "restify": "^4.0.3",
+    "supertest": "^1.1.0",
+    "tape": "^4.4.0"
   },
   "scripts": {
     "test": "tape test/*.js",

--- a/test/test-swaggerize.js
+++ b/test/test-swaggerize.js
@@ -154,7 +154,7 @@ test('input validation', function (t) {
 
         request(server).post('/v1/petstore/pets').send('').end(function (error, response) {
             t.ok(!error, 'no error.');
-            t.strictEqual(response.statusCode, 400, '400 status.');
+            t.strictEqual(response.statusCode, 500, '500 status.');
         });
     });
 


### PR DESCRIPTION
Instead, pass error to middleware and let the clients handle / remap the error message / status code in their own error handlers.

This way rather than returning empty payload, clients can iterate through the error objects and decorate as needed.

Once error is passed down, it could be used in formatters, ex:

```
var server = restify.createServer({
    formatters: {
        'application/json': function formatFoo(req, res, body, cb) {
            if (body instanceof Error) {
                return cb(null, JSON.stringify(new restify.errors.InvalidContentError({
                    message: body.message
                }).body));
            } else {
                return cb(null, util.inspect(body));
            }
        }
    }
});
```

More info on why we shouldn't be using res.send: https://github.com/restify/node-restify/issues/948
Plus, it will be even easier to catch this in restify 5, with: https://github.com/restify/node-restify/pull/892
